### PR TITLE
Nckw comments from dong hee kim

### DIFF
--- a/trunk/EXO-12-055.tex
+++ b/trunk/EXO-12-055.tex
@@ -71,10 +71,9 @@ pdfkeywords={CMS, physics, software, computing}}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 This paper describes a search for dark matter (DM) in events containing an
 energetic jet and an imbalance of transverse energy (\ETm) in 
-proton-proton (pp) collisions at the Large Hadron Collider (LHC) at a
-centre-of-mass energy of 8 TeV. The data were collected using the Compact Muon
-Solenoid (CMS) detector and correspond to an integrated luminosity of
-19.7\fbinv. 
+proton-proton (pp) collisions at a centre-of-mass energy of 8 TeV. 
+The data correspond to an integrated luminosity of  19.7\fbinv collected 
+using the Compact Muon Solenoid (CMS) detector at the Large Hadron Collider (LHC).
 
 The existence of DM is one of the most compelling sources of evidence
 for physics beyond the standard model (SM) of particle physics with a number of astrophysical
@@ -106,7 +105,7 @@ The events are categorized according to the nature of the jets in the
 event. The signal extraction is performed by considering the $\ETm$
 distribution in each event category, and using additional data control regions 
 to constrain the dominant backgrounds yielding improvements of roughly 60\% and 40\% respectively 
-in exclusion limits compared to the previous CMS monojet analysis~\cite{monojet1}.
+in exclusion limits in comparison with the previous CMS monojet analysis~\cite{monojet1}.
 
 This paper is structured as follows: Section 3 outlines the DM models
 explored as signal hypotheses; Section 4 provides a description of the
@@ -118,7 +117,7 @@ the context of simplified models for DM production.
 %===============================================================================
 \section{CMS detector}
 
-The CMS detector, described in detail in ref.~\cite{CMSdetector}, is a
+The CMS detector, described in detail in Ref.~\cite{CMSdetector}, is a
 multi-purpose apparatus designed to study high-transverse momentum($\pt$) physics processes in
 proton-proton and heavy-ion collisions.  A superconducting solenoid occupies its
 central region, providing a magnetic field of 3.8\unit{T} parallel to the beam
@@ -162,7 +161,7 @@ g_{SM}^q Z''_{\mu} \bar{q}\gamma^{\mu}\gamma^5q - m_{\rm DM} \bar{\chi}\chi,\,
 assuming pure scalar, pseudoscalar, vector, and axial vector mediated
 interactions denoted by $S,~P,~Z'$ and $Z''$ mediators, respectively.  The
 terms $g_{\mathrm{DM}}$ and $g_{\mathrm{SM}}$ denote the couplings
-of the mediator to the DM particle and to standard model particles respectively~\cite{Harris:2014hga}.  
+of the mediator to the DM particle and to SM particles, respectively~\cite{Harris:2014hga}.  
 The choice of the split in terms of axial vector and vector mediators in the Lagrangian is to
 parallel the existing separation with direct detection, into spin-dependent and
 spin-independent interactions. Here, spin-independent can refer to either vector
@@ -189,7 +188,7 @@ mono-V or monojet signatures follow from the presence of a V-boson or
 jet in the initial state. In all models, the coupling of the mediator to 
 SM particles is taken as unity ($g_{\mathrm{SM}}=1$) along with the DM coupling ($g_{\mathrm{DM}}=1$). 
 For the scalar and pseudoscalar models, this
-denotes a Yukawa coupling to standard model particles. For all models
+denotes a Yukawa coupling to SM particles. For all models
 considered, the width is fixed under the minimum width constraint requiring that
 only quarks and DM particles couple to the mediator~\cite{Harris:2014hga}.
 
@@ -213,7 +212,8 @@ and kinematic properties of the signal.
 \includegraphics[angle=0,scale=1.1,width=0.36\textwidth]{figures/monojet1.pdf}
 \label{fig:monojet1} } 
 \caption{Diagrams for production of DM via mediator (X) in the cases
-  of a scalar mediator providing (a) monojet and (b) mono-V signatures. (c) Diagram for production of DM via a vector mediator.\label{fig:monoXfeyn}} \end{figure}
+  of a scalar mediator providing (a) monojet and (b) mono-V signatures. 
+  (c) Diagram for production of DM via a vector mediator.\label{fig:monoXfeyn}} \end{figure}
 
 
 
@@ -233,9 +233,9 @@ $|\eta|<2.6$. The $\ETm$ is  calculated using the particle flow (PF) reconstruct
 algorithm~\cite{CMS-PAS-PFT-09-001} which optimally combines information from various components 
 of the CMS detector to reconstruct and identify individual particles. 
 The lowest threshold on \ETm for event selection is set at 200 GeV 
-in order to maintain a trigger efficiency greater than 99\%.
+in order to maintain a trigger efficiency greater than 99\% for selected events. 
 
-Jets are reconstructed from the clustering of particle flow objects using both 
+Jets are reconstructed from the clustering of PF objects using both 
 the anti-$k_{\textrm{T}}$ algorithm~\cite{Cacciari:2008gp} with 0.5 (ak5 jet) as
 the distance parameter, and the Cambridge/Aachen algorithm~\cite{cajets} with
 0.8 distance parameter (ca8). The leading jet is further required to be well
@@ -317,7 +317,9 @@ Distributions in boosted events before the jet mass cut of (a) $\tau_2/\tau_1$
 and (b) $m_{\mathrm{prune}}$ for ca8 jets. A cut of $\tau_2/\tau_1 < $ 0.5 has been applied in (b). 
 The discrepancy between data and simulation is covered by systematic uncertainties (not shown). 
 The dashed red line shows the expected distribution for scalar-mediated DM production with 
-$m_{\mathrm{DM}} = 10$ GeV and $m_{\mathrm{MED}} = 125$ GeV.}
+$m_{\mathrm{DM}} = 10$ GeV and $m_{\mathrm{MED}} = 125$ GeV. The gray bands in the bottom panels 
+indicate the statistical uncertainty from the limited number
+of simulated events.}
 \label{fig:boostvtagvars}\end{center}\end{figure*}
 
 In cases where the electroweak boson has insufficient boost for
@@ -343,7 +345,8 @@ The MVA distribution for V-tag events in simulation and data after signal cuts f
 (a) $\pt < 160$ GeV and (b) $\pt > 160$ GeV. At a $\pt$ of about 160 GeV, 
 the jets begin to overlap. The dashed red line shows the expected distribution 
 for scalar-mediated DM production with $m_{\mathrm{DM}} = 10$ GeV and $m_{\mathrm{MED}} = 125$ 
-GeV.}\label{fig:vtagger}\end{center}\end{figure*}
+GeV. The gray bands in the bottom panels indicate the statistical uncertainty from the limited number
+of simulated events.}\label{fig:vtagger}\end{center}\end{figure*}
 
 To reduce contamination from background processes containing a top quark, the events are rejected if they
 contain a b-tagged jet, defined using an MVA containing secondary vertex information  (``CSV
@@ -378,7 +381,7 @@ events and data, after the signal selection for all three event categories
 combined. The dashed red line shows the expected distribution assuming vector
 mediated DM production with $m_{\mathrm{DM}}=10$ GeV and $m_{\mathrm{MED}}=1$ TeV.  
 The gray bands in the bottom panels indicate the statistical uncertainty from the limited number
-of background MC events.} \label{fig:ptandmet}\end{center}\end{figure*}
+of simulated events.} \label{fig:ptandmet}\end{center}\end{figure*}
 
 
 \section{Background estimation}
@@ -388,10 +391,10 @@ backgrounds in a region of high $\ETm$.
 Significant improvements in terms of sensitivity can be
 expected if several bins in $\ETm$ are considered simultaneously. Further
 improvement is achieved by using control regions in data to 
-reduce the uncertainties on the predictions of the standard model background. These regions are
+reduce the uncertainties on the predictions of the SM backgrounds. These regions are
 statistically independent from the signal region and designed such that the expected contribution 
 from a potential signal is negligible. 
-A binned likelihood fit is performed in the range 250-1000 \gev (200-1000 \gev 
+A binned likelihood fit is performed in the range 250-1000 \gev (200-1000 \gev)  
 for the V-tag (monojet) events, where the binning is chosen to
 ensure each corresponding bin of a set of control regions is populated. The
 width of the highest $\ETm$ bin is chosen to provide ease of comparison to the previous
@@ -435,7 +438,7 @@ This is advantageous since the production
 cross-section of \phojets~is roughly three times that of the \Zvvjets~resulting in a
 smaller statistical uncertainty on the predicted background. 
  
-The \ETm spectra of the V+jets backgrounds are determined through the
+The \ETm spectra of the $\vjets$ backgrounds are determined through the
 use of the binned likelihood fit, simultaneously across all bins in the three control regions.
 The expected number of events $N_{i}$ in a given bin $i$ of fake \ETm, for a
 particular event category, is given by $N^{Z_{\mu\mu}|\gamma }_{i}=
@@ -475,7 +478,7 @@ and the muon efficiency times acceptance in the dimuon control region, while
 $R^{\gamma}_{i}$ account for the ratio of differential cross-sections between
 the $\Zjets$ and $\phojets$ processes and the efficiency times acceptance of the
 photon selection for the $\phojets$ control region. The differential cross sections 
-of photon and Z production are first corrected using NLO 
+of photon and Z production are first corrected using next-to-leading order   
 K-factors derived by comparing their $\pt$ distributions in events generated
 with Madgraph5\_aMC@NLO~\cite{amcatnlo}, to the
 distributions produced at leading order before deriving the factors 
@@ -501,7 +504,7 @@ uncertainty to be uncorrelated across bins of \ETm. The
 uncertainties in the muon selection efficiency, photon selection efficiency, and
 photon purity are included and fully correlated across the event categories and
 control regions, where relevant. The results of a
-fit to the control regions are shown in Figure~\ref{fig:combined_fit_result}.
+fit to the control regions are shown in Fig.~\ref{fig:combined_fit_result}.
  
 \begin{figure*}[hbtp]\begin{center}
 \includegraphics[width=0.32\textwidth]{figures/post_fit_photon_monojet.pdf}
@@ -552,7 +555,7 @@ reflected in these numbers.
 
 \begin{table}[htbp]
   \begin{center}
-    \caption{Expected yields of the standard model processes and their uncertainties per bin for the monojet category signal region after applying all corrections to the MC.
+    \caption{Expected yields of the SM processes and their uncertainties per bin for the monojet category signal region after the fit to the control regions.
       \label{tab:bkgmonojet}}
 	\scriptsize
     \begin{tabular}{c|c|c|c|c|c|c|c}
@@ -608,7 +611,7 @@ reflected in these numbers.
 
 \begin{table}[htbp]
   \begin{center}
-    \caption{Expected yields of the standard model processes and their uncertainties per bin for the V-resolved category signal region after applying all corrections to the MC.
+    \caption{Expected yields of the SM processes and their uncertainties per bin for the V-resolved category signal region after the fit to the control regions.
       \label{tab:bkgresolved}}
 	\scriptsize
     \begin{tabular}{l|c|c|c|c|c|c|c}
@@ -633,7 +636,7 @@ reflected in these numbers.
 \bigskip
 \bigskip
 \bigskip
-    \caption{Expected yields of the standard model processes and their uncertainties per bin for the V-boosted category signal region after applying all corrections to the MC.
+    \caption{Expected yields of the SM processes and their uncertainties per bin for the V-boosted category signal region after the fit to the control regions.
       \label{tab:bkgboosted}}
 	\scriptsize
     \begin{tabular}{l|c|c|c|c|c|c|c}

--- a/trunk/commands.tex
+++ b/trunk/commands.tex
@@ -1,12 +1,13 @@
-\newcommand{\Zmm}{\ensuremath{Z\to\mu^+\mu^-}}
-\newcommand{\Zvv}{\ensuremath{Z\to\nu\nu}}
-\newcommand{\Wlv}{\ensuremath{W\to l\nu}}
-\newcommand{\Zmmjets}{\ensuremath{Z(\mu\mu)+\textrm{jets}}}
-\newcommand{\Zjets}{\ensuremath{Z+\textrm{jets}}}
-\newcommand{\Zlljets}{\ensuremath{Z(ll)+\textrm{jets}}}
-\newcommand{\Zvvjets}{\ensuremath{Z(\nu\nu)+\textrm{jets}}}
-\newcommand{\Wlvjets}{\ensuremath{W(l\nu)+\textrm{jets}}}
-\newcommand{\Wmvjets}{\ensuremath{W(\mu\nu)+\textrm{jets}}}
+\newcommand{\Zmm}{\ensuremath{\textrm{Z}\to\mu^+\mu^-}}
+\newcommand{\Zvv}{\ensuremath{\textrm{Z}\to\nu\nu}}
+\newcommand{\Wlv}{\ensuremath{\textrm{W}\to l\nu}}
+\newcommand{\Zmmjets}{\ensuremath{\textrm{Z}(\mu\mu)+\textrm{jets}}}
+\newcommand{\Vjets}{\ensuremath{\textrm{V}+\textrm{jets}}}
+\newcommand{\Zjets}{\ensuremath{\textrm{Z}+\textrm{jets}}}
+\newcommand{\Zlljets}{\ensuremath{\textrm{Z}(ll)+\textrm{jets}}}
+\newcommand{\Zvvjets}{\ensuremath{\textrm{Z}(\nu\nu)+\textrm{jets}}}
+\newcommand{\Wlvjets}{\ensuremath{\textrm{W}(l\nu)+\textrm{jets}}}
+\newcommand{\Wmvjets}{\ensuremath{\textrm{W}(\mu\nu)+\textrm{jets}}}
 \newcommand{\phojets}{\ensuremath{\gamma+\textrm{jets}}}
 \newcommand{\brhiggs}{\ensuremath{0.62}}
 \newcommand{\higgsbr}{\ensuremath{0.62}}

--- a/trunk/comments_DHK.txt
+++ b/trunk/comments_DHK.txt
@@ -1,0 +1,108 @@
+Dear Authors,
+
+It was nice to read about the paper. Here is the comments from the Kyungpook National University. Of particular this paper is important in view of using the Simplified DM model instead of EFT as a  first attempt. However it is not clear whether comparisons with direct detection experiments can be justified with the one choice of simple couplings(g_DM = g_SM = 1) or not. Maybe the two extreme choices of the coupling, that is, 0.25 and 1.45 instead of 1) may be better if we want to compare with DD experimental results.
+
+We have chosen here gSM=gDM=1. This analysis was performed before the reccomendations for Run2 were available and re-running results would require significant effort. We agree it is good to add different assumptions and 
+for sure this will be included in coming updates including the Run-2 data
+
+Comments Type A :
+L3-5: (suggestion) in pp collisions at a centre-of-mass energy of 8 TeV. The data sample correspond to an integrated luminosity of 19.7 fb^-1 collected using the Compact Muon Solenoid (CMS) at the Large Hadron Collider (LHC).
+
+That does sound cleaner. We have adopted this suggestion
+
+Abbreviation 1: "dark matter" --> "DM" L6, L48, 55, 67, 282, 299, 323
+
+Done, thanks
+
+L24 substructure of. --> substructure.
+Fixed
+
+L26 compared to --> in comparison with
+
+Done
+
+Abbreviation 2: "standard model" --> "SM" L55, L74, Table1, Table2, Table3,
+
+Done
+
+L55: "particles respectively" --> "particles, respectively"
+
+Done
+
+L33 "ref" -> "Ref"
+
+Done
+
+L97 "particle flow" -> "PF“
+
+Done
+
+
+L174 to simultaneously constrain --> to constrain simultaneously
+
+Fixed via another comment
+
+L176: "GeV for" --> "GeV) for"
+
+Done
+
+L191: "vector" should be in roman type
+Done
+
+L191: "GeV," --> "GeV."
+
+Done
+
+L206: "V+jets" --> "V + jets"
+
+Done
+
+L221: "NLO" -> "next-to-leading order" (to be consistent with "leading order")
+
+Done
+
+L220, L270, L327: "cross section" -> "cross-section"
+
+We have adopted “cross section” everywhere to be consistent (also with pub comm guidelines)
+
+L235: "Figure 5" --> "Fig. 5" (to be consistent with others (L151, L304, L305, ...)
+
+Done
+
+Caption of Figure2: "The discrepancy between data and simulation is covered by systematic uncertainties (not shown)." can be removed, It was already written in the text (L135-L140)
+
+Removed, replaced with “Uncertainty bands only include statistical precision of the simulation” which is now there
+
+Table1,2,3 : "bin(GeV)" should be in roman type
+
+Done
+
+Type B (or type B-like) :
+
+Figure 2 caption: /// systematic uncertainties (not shown) /// wondering why not to show them in the plots
+
+For the purposes of a plot, we prefer not to show systematic uncertainties since the dominant sources of the systematics are from the data-driven estimate used to determine the backgrounds which is not yet discussed.
+
+L.20 Just general question, does "hadronic decay" include heavy quark like b ?
+
+Yes but there are vetos on b-jets (to reduce top contribution)
+
+L.71 This sentence makes a confusion. Does this paper consider mono-V and mono-jet from initial states ? If so, the initial state radiation(ISR) diagrams are needed in fig 1(or diagram © is wrong and need to be replaced the diagram with ISR(??), too. and what is the generator for them ?
+
+Indeed, the diagram is updated to include an ISR jet. The generators are stated.
+
+L.75 The model in figure 1(b), the mediator couples with vector boson. How does this affect to width ?
+
+The width is calculated including this using in this case Higgs-like couplings.
+
+L.81 What is the mechanism for the mediator mass to give affect to shower scale ? It is better if there is a reference.
+
+That is not the point of this line, its not the mass which has the effect but rather  the choice is the mediator mass for the scale. Alternative choices for the scale give different yields. The text is now clarified a bit on this point.
+
+L.95 What samples to study trigger efficiency ? Trigger efficiency > 99% means for DM signal ?
+
+This means with respect to our offline selection (all events).
+
+L.292 Same issue with L.75. It looks this analysis is already using scalar mediator coupling with V, so X -> V V* is also possible. So "when assuming the mediator only couples to fermions" looks not appropriate sentence. It looks like the excluded limits are for Br(X->fermion pair)*sigma.
+
+We have also included the model where no coupling to V is present (described better in the earlier text now). This is what the blue scale is indicating.


### PR DESCRIPTION
Dear Authors,

It was nice to read about the paper. Here is the comments from the Kyungpook National University. Of particular this paper is important in view of using the Simplified DM model instead of EFT as a  first attempt. However it is not clear whether comparisons with direct detection experiments can be justified with the one choice of simple couplings(g_DM = g_SM = 1) or not. Maybe the two extreme choices of the coupling, that is, 0.25 and 1.45 instead of 1) may be better if we want to compare with DD experimental results.

We have chosen here gSM=gDM=1. This analysis was performed before the reccomendations for Run2 were available and re-running results would require significant effort. We agree it is good to add different assumptions and
for sure this will be included in coming updates including the Run-2 data

Comments Type A :
L3-5: (suggestion) in pp collisions at a centre-of-mass energy of 8 TeV. The data sample correspond to an integrated luminosity of 19.7 fb^-1 collected using the Compact Muon Solenoid (CMS) at the Large Hadron Collider (LHC).

That does sound cleaner. We have adopted this suggestion

Abbreviation 1: "dark matter" --> "DM" L6, L48, 55, 67, 282, 299, 323

Done, thanks

L24 substructure of. --> substructure.
Fixed

L26 compared to --> in comparison with

Done

Abbreviation 2: "standard model" --> "SM" L55, L74, Table1, Table2, Table3,

Done

L55: "particles respectively" --> "particles, respectively"

Done

L33 "ref" -> "Ref"

Done

L97 "particle flow" -> "PF“

Done

L174 to simultaneously constrain --> to constrain simultaneously

Fixed via another comment

L176: "GeV for" --> "GeV) for"

Done

L191: "vector" should be in roman type
Done

L191: "GeV," --> "GeV."

Done

L206: "V+jets" --> "V + jets"

Done

L221: "NLO" -> "next-to-leading order" (to be consistent with "leading order")

Done

L220, L270, L327: "cross section" -> "cross-section"

We have adopted “cross section” everywhere to be consistent (also with pub comm guidelines)

L235: "Figure 5" --> "Fig. 5" (to be consistent with others (L151, L304, L305, ...)

Done

Caption of Figure2: "The discrepancy between data and simulation is covered by systematic uncertainties (not shown)." can be removed, It was already written in the text (L135-L140)

Removed, replaced with “Uncertainty bands only include statistical precision of the simulation” which is now there

Table1,2,3 : "bin(GeV)" should be in roman type

Done

Type B (or type B-like) :

Figure 2 caption: /// systematic uncertainties (not shown) /// wondering why not to show them in the plots

For the purposes of a plot, we prefer not to show systematic uncertainties since the dominant sources of the systematics are from the data-driven estimate used to determine the backgrounds which is not yet discussed.

L.20 Just general question, does "hadronic decay" include heavy quark like b ?

Yes but there are vetos on b-jets (to reduce top contribution)

L.71 This sentence makes a confusion. Does this paper consider mono-V and mono-jet from initial states ? If so, the initial state radiation(ISR) diagrams are needed in fig 1(or diagram © is wrong and need to be replaced the diagram with ISR(??), too. and what is the generator for them ?

Indeed, the diagram is updated to include an ISR jet. The generators are stated.

L.75 The model in figure 1(b), the mediator couples with vector boson. How does this affect to width ?

The width is calculated including this using in this case Higgs-like couplings.

L.81 What is the mechanism for the mediator mass to give affect to shower scale ? It is better if there is a reference.

That is not the point of this line, its not the mass which has the effect but rather  the choice is the mediator mass for the scale. Alternative choices for the scale give different yields. The text is now clarified a bit on this point.

L.95 What samples to study trigger efficiency ? Trigger efficiency > 99% means for DM signal ?

This means with respect to our offline selection (all events).

L.292 Same issue with L.75. It looks this analysis is already using scalar mediator coupling with V, so X -> V V\* is also possible. So "when assuming the mediator only couples to fermions" looks not appropriate sentence. It looks like the excluded limits are for Br(X->fermion pair)*sigma.

We have also included the model where no coupling to V is present (described better in the earlier text now). This is what the blue scale is indicating.
