### PR TITLE
Comments from ITEP

### DIFF
--- a/trunk/EXO-12-055.tex
+++ b/trunk/EXO-12-055.tex
@@ -108,7 +108,8 @@ distribution in each event category, and using additional data control regions
 to constrain the dominant backgrounds yielding improvements of roughly 60\% and 40\% respectively 
 in exclusion limits compared to the previous CMS monojet analysis~\cite{monojet1}.
 
-This paper is structured as follows: Section 3 outlines the DM models
+This paper is structured as follows:Section 2 provides a description of the 
+CMS detector; Section 3 outlines the DM models
 explored as signal hypotheses; Section 4 provides a description of the
 physics object reconstruction, event selection and categorization used in
 the search; Section 5 describes the background modelling used for the signal
@@ -240,9 +241,9 @@ the anti-$k_{\textrm{T}}$ algorithm~\cite{Cacciari:2008gp} with 0.5 (ak5 jet) as
 the distance parameter, and the Cambridge/Aachen algorithm~\cite{cajets} with
 0.8 distance parameter (ca8). The leading jet is further required to be well
 identified, using a standard set of identification criteria~\cite{jec}. The jets
-are corrected for contamination from additional overlapping
-interactions occuring at the same time  on the basis of the observed event energy density~\cite{jec}. 
-Data-driven corrections are then applied to
+are corrected for contamination from additional, synchornous
+interactions (pileup, PU) on the basis of the observed event energy density~\cite{jec}. 
+Further corrections are then applied to
 calibrate the absolute scale of the jet energy~\cite{jec}.
 
 The \ETm is calculated as the magnitude of the negative vector sum of the
@@ -270,7 +271,7 @@ to the parton shower following the MLM matching
 prescription~\cite{Mangano:2006rw}.  Additionally a single-top background
 sample, produced with POWHEG~\cite{Nason:2004rx,Frixione:2007vw,powheg,Alioli:2010xd,Alioli:2009je}, and a set of diboson samples,
 produced directly with PYTHIA6, are added.  The MC samples are corrected to
-account for the distribution of the number of additional pileup 
+account for the distribution of the number of additional PU 
 interactions observed in the 8 TeV dataset. Both signal and background samples are
 additionally corrected to account for the mis-modelling of hadronic recoil in
 simulation following the procedure described in Ref.~\cite{CMS-PAS-JME-12-002}.

--- a/trunk/comments_ITEP.txt
+++ b/trunk/comments_ITEP.txt
@@ -1,0 +1,64 @@
+Type B comments
+
+
+l.82. Please, clarify "... to be up to 30% in the expected signal yield..."
+
+What is 30 % ? Difference between what and what setup ?
+
+ This is now clarifed. It is relating the difference in the total signal yield changing the hadronisation scale from the mediator mass to the pt of the mediator.
+
+l.101 remove "Data-driven". Corrections are based both of MC (absolute) and
+
+data (for residual data/MC difference).
+Done
+
+l.241 Please, provide an arguments here about QCD uncertaunty of 50% even if you refer
+
+to the previous analysis [1].
+
+Added a sentence to mention the Data/MC comparison in inverted selection region used to determine 50%
+
+ll.267-273 Did you take into account the theoretical uncertainty of the signal acceptance ?
+
+ Yes, but these are by far much smaller than the variation from the scale uncertainties on the cross-section
+
+Fig.2: What is a meaning of dashed areas around MC histogram in fig. (b)?
+
+ This is (now) explained in the caption. They are MC Stat uncertainties
+
+Fig.7. Instead of limits on the signal strength it would be good to have the limits
+
+on the cross-sections. It will be more useful then for theorists.
+
+ true, but also not possible in a “shape” analysis. We assume a model (the simplified model) and it is that we which do/do not exclude.
+
+Type A comments
+
+
+l.24 remove "of"
+
+Done
+
+ll.27-30. Section 2 in a description of CMS detector. Other section numbers should be increased by one (Section i => Section i+1)
+
+ Done, thanks
+
+l.100 "jets are corrected for pileup" => "the jet energy is corrected for
+
+the contribution from pileup"
+
+ Detail added
+
+l.113 "othogonal" -> "orthogonal"
+
+ Fixed
+
+Fig.6: "resolved" -> "V-resolved", "boosted" -> "V-boosted" in the titles
+
+of fig.(b) and (c)
+
+Done
+
+With kind regards,
+
+A.Nikitenko and V.Gavrilov for ITEP


### PR DESCRIPTION
Type B comments

l.82. Please, clarify "... to be up to 30% in the expected signal yield..."

What is 30 % ? Difference between what and what setup ?

 This is now clarifed. It is relating the difference in the total signal yield changing the hadronisation scale from the mediator mass to the pt of the mediator.

l.101 remove "Data-driven". Corrections are based both of MC (absolute) and

data (for residual data/MC difference).
Done

l.241 Please, provide an arguments here about QCD uncertaunty of 50% even if you refer

to the previous analysis [1].

Added a sentence to mention the Data/MC comparison in inverted selection region used to determine 50%

ll.267-273 Did you take into account the theoretical uncertainty of the signal acceptance ?

 Yes, but these are by far much smaller than the variation from the scale uncertainties on the cross-section

Fig.2: What is a meaning of dashed areas around MC histogram in fig. (b)?

 This is (now) explained in the caption. They are MC Stat uncertainties

Fig.7. Instead of limits on the signal strength it would be good to have the limits

on the cross-sections. It will be more useful then for theorists.

 true, but also not possible in a “shape” analysis. We assume a model (the simplified model) and it is that we which do/do not exclude.

Type A comments

l.24 remove "of"

Done

ll.27-30. Section 2 in a description of CMS detector. Other section numbers should be increased by one (Section i => Section i+1)

 Done, thanks

l.100 "jets are corrected for pileup" => "the jet energy is corrected for

the contribution from pileup"

 Detail added

l.113 "othogonal" -> "orthogonal"

 Fixed

Fig.6: "resolved" -> "V-resolved", "boosted" -> "V-boosted" in the titles

of fig.(b) and (c)

Done

With kind regards,

A.Nikitenko and V.Gavrilov for ITEP
