### PR TITLE
Comments from rutgers

### DIFF
--- a/trunk/EXO-12-055.tex
+++ b/trunk/EXO-12-055.tex
@@ -351,7 +351,8 @@ medium'')~\cite{BTAG}. Finally, the events are required to have $\ETm>250$ \gev.
 
 The events that do not qualify for either of the two V-tag categories are
 required to have one or two high \pt jets showing characteristics indicative of
-originating from a \emph{single} quark or gluon.  For this monojet category, at
+originating from a \emph{single} quark or gluon. This final category is referred to 
+herein as the monojet category. For the monojet category, at
 least one ak5 jet within $|\eta|<2.0$ with \pt greater than 150 \gev and a \ETm
 greater than 200 \gev is required.  As in the V-boosted category, events with a
 second ak5 jet close to the leading one ($\Delta\phi(j_1,j_2) < 2$) with

--- a/trunk/EXO-12-055.tex
+++ b/trunk/EXO-12-055.tex
@@ -80,9 +80,10 @@ for physics beyond the standard model (SM) of particle physics with a number of 
 observations suggesting an abundance of a non-baryonic form of matter in the
 universe. In many theories which extend the SM, the production of DM particles
 is possible at the LHC. Monojet searches~\cite{monojet1,monojet2} provide 
-a model-independent means of exploring DM production at the LHC, while mono-V, 
-V=W or Z boson, searches~\cite{monolep,Aad:2014vka,Aad:2013oja,ATLAS:2014wra} target the
-associated production of DM with SM vector bosons.
+sensitivity to a wide range of models for  DM production at the LHC, while mono-V 
+(where V=W or Z boson) searches~\cite{monolep,Aad:2014vka,Aad:2013oja,ATLAS:2014wra} target models with 
+associated production of DM with SM vector bosons. While the mono-V searches target more specific models, 
+they benefit from smaller contributions from SM backgrounds. 
 %which can be enhanced in
 %theories with non-universal DM couplings~\cite{IVDM}.  
 The interpretation of
@@ -97,10 +98,11 @@ direct detection experiments while retaining validity as a description of DM
 production across the entire kinematic region accessible at the LHC. 
 
 This search is the first at CMS to target the hadronic decay modes of the vector
-bosons in the mono-V channels. A multivariate V-tagging technique is employed to
-identify the individual jets from moderately boosted vector bosons. The
-exploration of mono-V production at high boost utilises recently developed
-techniques designed to exploit information available in a jet's substructure.  
+bosons in the mono-V channels. The 
+mono-V search uses recently developed techniques designed to exploit information 
+available in the jet's substructure when the V-boson is 
+highly boosted and uses a multivariate V-tagging technique to
+identify the individual jets from moderately boosted V-bosons.  
 The events are categorized according to the nature of the jets in the
 event. The signal extraction is performed by considering the $\ETm$
 distribution in each event category, and using additional data control regions 
@@ -163,6 +165,8 @@ assuming pure scalar, pseudoscalar, vector, and axial vector mediated
 interactions denoted by $S,~P,~Z'$ and $Z''$ mediators, respectively.  The
 terms $g_{\mathrm{DM}}$ and $g_{\mathrm{SM}}$ denote the couplings
 of the mediator to the DM particle and to SM particles, respectively~\cite{Harris:2014hga}.  
+In all models considered, the couplings are assumed to be unity ($g_{\mathrm{SM}}=g_{\mathrm{DM}}=1$). 
+For the scalar and pseudoscalar models, this denotes a Yukawa coupling to SM particles.
 The choice of the split in terms of axial vector and vector mediators in the Lagrangian is to
 parallel the existing separation with direct detection, into spin-dependent and
 spin-independent interactions. Here, spin-independent can refer to either vector
@@ -170,7 +174,7 @@ or scalar mediated interactions, between which direct detection makes no
 distinction, while spin-dependent interactions refer to axial vector mediated
 processes.
  
-Pseudoscalar DM-nucleon interaction cross sections are suppressed at non-relativitstic DM 
+Pseudoscalar DM-nucleon interaction cross sections are suppressed at non-relativistic DM 
 velocities therefore the sensitivity from the direct detection experiments is limited~\cite{Haisch:2012kf,LopezHonorez:2012kv}.  
 An extension to the scalar and pseudoscalar can
 be performed by allowing the scalar and pseudoscalar interactions to undergo
@@ -186,12 +190,11 @@ denoted herein as $fermionic$.
 For the spin-1 signatures, DM is produced in
 an analogous way to Z boson production (Fig.~\ref{fig:monoXfeyn}(c)). The
 mono-V or monojet signatures follow from the presence of a V-boson or
-jet in the initial state. In all models, the coupling of the mediator to 
-SM particles is taken as unity ($g_{\mathrm{SM}}=1$) along with the DM coupling ($g_{\mathrm{DM}}=1$). 
-For the scalar and pseudoscalar models, this
-denotes a Yukawa coupling to SM particles. For all models
-considered, the width is fixed under the minimum width constraint requiring that
-only quarks and DM particles couple to the mediator~\cite{Harris:2014hga}.
+jet in the initial state. 
+For the fermionic models, the width is determined under the minimum width constraint 
+requiring that only quarks and DM particles couple to the mediator. For the case in 
+which couplings between the mediator and V-bosons are allowed, the width is modified to 
+account for the additional contributions which these couplings allow~\cite{Harris:2014hga}.
 
 In order to model the expected contribution from these signals, simulated 
 events are generated using MCFM~\cite{mcfm} for the monojet final state, and
@@ -200,7 +203,7 @@ All signal models are generated at leading order, using
 PYTHIA6~\cite{Sjostrand:2006za} for parton showers and hadronization, and Geant4~\cite{geant4} for simulation of the CMS detector.  
 For the monojet signal, the generation is performed using the mediator mass for both the generation and hadronisation scale. 
 An alternative choice taking the boson $\pt$ for the hadronisation scale was found to result in differences between  
-$30-80$\% in the expected signal yield in the relevant kinematic region for mediator masses above 400 GeV. 
+$30-80$\% in the expected signal yield in the relevant kinematic region for mediator masses above 400\GeV. 
 For scalar and pseudoscalar mediated DM production, the finite top quark mass is taken 
 into account for both the inclusive cross-section 
 and kinematic properties of the signal. 
@@ -225,16 +228,16 @@ one or more high-\pt jets.
 Events are reconstructed with the CMS detector, following the standard CMS
 reconstruction~\cite{CMSdetector}. 
 
-The data used for this analysis are collected using either of two triggers
-designed to record events containing large \ETm. The first requires an \ETm of
-greater than 120 \gev, calculated only using information from the calorimeters,
-while the second requires an \ETm greater than 95~\gev or 105~\gev, depending on
-the data-taking period, together with a jet of \pt$>80$ \gev and
+The data used for this analysis are collected using two \ETm triggers 
+The first requires an \ETm of
+greater than 120 \GeV, calculated only using information from the calorimeters,
+while the second requires an \ETm greater than 95~\GeV or 105~\GeV, depending on
+the data-taking period, together with at least one jet of \pt$>80$ \GeV and
 $|\eta|<2.6$. The $\ETm$ is  calculated using the particle flow (PF) reconstruction
 algorithm~\cite{CMS-PAS-PFT-09-001} which optimally combines information from various components 
 of the CMS detector to reconstruct and identify individual particles. 
-The lowest threshold on \ETm for event selection is set at 200 GeV 
-in order to maintain a trigger efficiency greater than 99\% for selected events. 
+The lowest threshold on \ETm for event selection is set at 200 \GeV 
+in order to ensure Done a trigger efficiency greater than 99\% for selected events. 
 
 Jets are reconstructed from the clustering of PF objects using both 
 the anti-$k_{\textrm{T}}$ algorithm~\cite{Cacciari:2008gp} with 0.5 (ak5 jet) as
@@ -250,11 +253,11 @@ The \ETm is calculated as the magnitude of the negative vector sum of the
 transverse momenta of all final state particles, which are reconstructed using PF.  
 Events with a large mis-reconstructed \ETm are removed by applying a quality filter on the tracker, 
 ECAL, HCAL and muon detector data.
-The angle between the \ETm and the leading jet in the plane transverse to the
+The angle between the \ETm vector and the leading jet in the plane transverse to the
 beam line, $\Delta\phi$, is required to be larger than 2 to reduce the
 contribution from QCD multijet events. Finally, events are vetoed if they
 contain at least one well-identified electron, photon or muon with
-$\pt>10$~\gev, or a tau with $\pt>15$~\gev. The electron, tau and photon vetoes require that the  
+$\pt>10$~\GeV, or a tau with $\pt>15$~\GeV. The electron, tau and photon vetoes require that the  
 identified object be isolated using standard PF isolation algorithms~\cite{Beaudette:2014cea}.
 
 Selected events are classified based on the
@@ -287,19 +290,19 @@ simulation following the procedure described in Ref.~\cite{CMS-PAS-JME-12-002}.
 If the vector boson decays hadronically and has sufficiently large transverse
 momentum, both its hadronic decay products are captured by a single
 reconstructed ``fat'' jet.  Events in the V-boosted category are
-required to have a reconstructed ca8 jet with $\pt>200$ \gev and  $\ETm>250$
-\gev.  Further selection criteria are applied to improve the vector boson jet purity by
-cutting on ``subjettiness'' ratio $\tau_2/\tau_1$ as defined 
+required to have a reconstructed ca8 jet with $\pt>200$ \GeV and  $\ETm>250$
+\GeV.  Further selection criteria are applied to improve the vector boson jet purity by
+cutting on the ``N-subjettiness'' ratio $\tau_2/\tau_1$ as defined 
 in Refs.~\cite{Thaler:2010tr,Thaler:2011gf}, which identifies jets with a two sub-jet
 topology, and the pruned jet mass ($m_{\mathrm{prune}}$)~\cite{Ellis:2009me}.
 The $\tau_2/\tau_1$ ratio is required to be smaller than 0.5 and $m_{\mathrm{prune}}$ 
-is required to be in the range 60-110 \gev.  
+is required to be in the range 60-110 \GeV.  
 Events which contain additional jets close to the ca8 jet, but no closer than $\Delta R <
 0.5$, are selected to include the frequent cases in which initial state
-radiation yields additional jets. If an ak5 jet with $\pt>30$~\gev and $|\eta|<2.5$
-is reconstructed, and the opening azimuthal angle between it and the ca8 jet,
-$\Delta\phi(\mathrm{ak5,ca8})$, is smaller than 2,~the event is selected. Events
-with more than one ak5 jet with $\pt>30$ \gev and $|\eta|<2.5$, reconstructed
+radiation yields additional jets. If an ak5 jet with $\pt>30$~\GeV and $|\eta|<2.5$
+is reconstructed, and the opening azimuthal angle between it and the ca8 jet
+is smaller than 2, the event is selected, otherwise it is rejected. Events
+with more than one ak5 jet with $\pt>30$ \GeV and $|\eta|<2.5$, reconstructed
 at $\Delta R> 0.5$ with respect to the ca8 jet are rejected.
 Figure~\ref{fig:boostvtagvars} shows the distributions of $\tau_2/\tau_1$ and
 $m_{\mathrm{prune}}$, before the application of the jet mass cut, in simulation
@@ -318,7 +321,7 @@ Distributions in boosted events before the jet mass cut of (a) $\tau_2/\tau_1$
 and (b) $m_{\mathrm{prune}}$ for ca8 jets. A cut of $\tau_2/\tau_1 < $ 0.5 has been applied in (b). 
 The discrepancy between data and simulation is covered by systematic uncertainties (not shown). 
 The dashed red line shows the expected distribution for scalar-mediated DM production with 
-$m_{\mathrm{DM}} = 10$ GeV and $m_{\mathrm{MED}} = 125$ GeV. The gray bands in the bottom panels 
+$m_{\mathrm{DM}} = 10$\GeV and $m_{\mathrm{MED}} = 125$\GeV. The gray bands in the bottom panels 
 indicate the statistical uncertainty from the limited number
 of simulated events.}
 \label{fig:boostvtagvars}\end{center}\end{figure*}
@@ -327,8 +330,8 @@ In cases where the electroweak boson has insufficient boost for
 its hadronic decay to be fully contained in a single reconstructed fat jet, a
 selection that looks for decays into a pair of ak5 jets is applied to recover
 the event if it fails the V-boosted selection.  The selection requires that each jet
-has $\pt>30$ GeV and $|\eta|<2.5$ and that the dijet has a mass in the range 
-60-110 \gev, consistent with originating from a W or Z boson. To further reduce
+has $\pt>30$\GeV and $|\eta|<2.5$ and that the dijet has a mass in the range 
+60-110 \GeV, consistent with originating from a W or Z boson. To further reduce
 the combinatorial background in the V-resolved category, a multivariate (MVA)  
 selection criterion is applied. The inputs to the MVA are the likelihood-based discriminators which distinguish 
 quark from gluon jets~\cite{JME-14-002}, the jet pull angle~\cite{Gallicchio:2010sw} 
@@ -343,26 +346,57 @@ Fig.~\ref{fig:vtagger}.
 \subfloat[][]{ \includegraphics[width=0.49\textwidth]{figures/res_vmvalog_1.pdf}
 } \caption{ 
 The MVA distribution for V-tag events in simulation and data after signal cuts for 
-(a) $\pt < 160$ GeV and (b) $\pt > 160$ GeV. At a $\pt$ of about 160 GeV, 
+(a) $\pt < 160$\GeV and (b) $\pt > 160$\GeV. At a $\pt$ of about 160\GeV, 
 the jets begin to overlap. The dashed red line shows the expected distribution 
-for scalar-mediated DM production with $m_{\mathrm{DM}} = 10$ GeV and $m_{\mathrm{MED}} = 125$ 
-GeV. The gray bands in the bottom panels indicate the statistical uncertainty from the limited number
+for scalar-mediated DM production with $m_{\mathrm{DM}} = 10$\GeV and $m_{\mathrm{MED}} = 125$\GeV. 
+The gray bands in the bottom panels indicate the statistical uncertainty from the limited number
 of simulated events.}\label{fig:vtagger}\end{center}\end{figure*}
 
 To reduce contamination from background processes containing a top quark, the events are rejected if they
 contain a b-tagged jet, defined using an MVA containing secondary vertex information  (``CSV
-medium'')~\cite{BTAG}. Finally, the events are required to have $\ETm>250$ \gev. 
+medium'')~\cite{BTAG}. Finally, the events are required to have $\ETm>250$ \GeV. 
 
 The events that do not qualify for either of the two V-tag categories are
 required to have one or two high \pt jets showing characteristics indicative of
 originating from a \emph{single} quark or gluon. This final category is referred to 
 herein as the monojet category. For the monojet category, at
-least one ak5 jet within $|\eta|<2.0$ with \pt greater than 150 \gev and a \ETm
-greater than 200 \gev is required.  As in the V-boosted category, events with a
+least one ak5 jet within $|\eta|<2.0$ with \pt greater than 150 \GeV and a \ETm
+greater than 200 \GeV is required.  As in the V-boosted category, events with a
 second ak5 jet close to the leading one ($\Delta\phi(j_1,j_2) < 2$) with
-$\pt>30$ GeV and $|\eta|<2.5$ are selected to allow the frequent cases where
+$\pt>30$\GeV and $|\eta|<2.5$ are selected to allow the frequent cases where
 initial state radiation yields two jets.  Events with three or more ak5 jets
-with $\pt>30$ \gev and $|\eta|<2.5$ are rejected.
+with $\pt>30$ \GeV and $|\eta|<2.5$ are rejected. Table~\ref{tab:selection} gives a 
+summary of the event selection in the three categories. 
+
+
+\begin{table}[h!]
+	\caption{Event selections for the V-boosted, V-resolved and monojet categories
+	The requirements 
+	on $\pt^{\mathrm{j}}$ and $|\eta|^{\mathrm{j}}$ refer to the highest $\pt$ jet in the 
+	V-resolved and monojet categories, and the  
+	fat jet in the V-boosted category. The priority for event selection proceeds as 
+	first the V-boosted, followed by the V-resolved and finally the monojet. Events 
+	which pass a given selection are not allowed to enter a subsequent category.}
+ \label{tab:ggh_vjj_selection}
+ \begin{center} 
+ \begin{tabular}{l|c c|c c}
+ \multicolumn{1}{l|}{}	     & \multicolumn{2}{c|}{13 TeV}  &\multicolumn{2}{c}{8 TeV} \\
+ \multicolumn{1}{l|}{}	     & $\vjj$-tag & monojet        & $\vjj$-tag & monojet     \\ 
+ \hline
+ \hline
+  $\pt^{\mathrm{j}}$     	     &  $>250$ GeV & $>100$ GeV  & $>200$ GeV & $>150$ GeV  \\
+  $|\eta|^{\mathrm{j}}$     	     &  $<2.4$	   & $<2.5$	 & \multicolumn{2}{c}{$<2$} \\
+  $\ETm$     		     	     &  $>250$ GeV & $>200$ GeV  & $>250$ GeV & $>200$ GeV  \\
+  $\tau_2/\tau_1$      		     & $<0.6$ 	   & - 	         & $<0.5$     & -  \\
+  $\mathrm{m_{prune}}$      	     & 65-105 GeV  & - 	         & 60-110 GeV     & -  \\
+  $\mindphi^{1}$      		     &\multicolumn{2}{c|}{$>0.5$}& \multicolumn{2}{c}{$>2$} \\
+  $\mathrm{N}_{\mathrm{j}}$  	     &\multicolumn{2}{c|}{-} 	 & \multicolumn{2}{c}{$=1^{2}$} \\
+ \hline
+ \end{tabular}
+ \end{center}\\
+\footnotesize{$^{2}$ An additional jet is allowed only if it falls within $\Delta\phi<2$ of the 
+leading jet (or fat jet for the V-boosted category).}
+\end{table}
 
 Figure~\ref{fig:ptandmet} shows the \ETm and leading jet $\pt$ distributions
 in data and simulation after selection for all three event classes combined. The
@@ -381,7 +415,7 @@ following section.
 } \caption{ Distributions of  (a) \ETm and (b) leading jet $\pt$ in simulated
 events and data, after the signal selection for all three event categories
 combined. The dashed red line shows the expected distribution assuming vector
-mediated DM production with $m_{\mathrm{DM}}=10$ GeV and $m_{\mathrm{MED}}=1$ TeV.  
+mediated DM production with $m_{\mathrm{DM}}=10$\GeV and $m_{\mathrm{MED}}=1$ TeV.  
 The gray bands in the bottom panels indicate the statistical uncertainty from the limited number
 of simulated events.} \label{fig:ptandmet}\end{center}\end{figure*}
 
@@ -396,8 +430,8 @@ improvement is achieved by using control regions in data to
 reduce the uncertainties on the predictions of the SM backgrounds. These regions are
 statistically independent from the signal region and designed such that the expected contribution 
 from a potential signal is negligible. 
-A binned likelihood fit is performed in the range 250-1000 \gev (200-1000 \gev)  
-for the V-tag (monojet) events, where the binning is chosen to
+A binned likelihood fit is performed in the ranges 250-1000 \GeV and 200-1000 \GeV 
+for the V-tag (V-boosted and V-resolved) and monojet events, respectively. The binning is chosen to
 ensure each corresponding bin of a set of control regions is populated. The
 width of the highest $\ETm$ bin is chosen to provide ease of comparison to the previous
 CMS search~\cite{monojet1}. 
@@ -405,20 +439,32 @@ CMS search~\cite{monojet1}.
 The background contributions from \Zvvjets~(\Wlvjets)~is determined using data 
 from dimuon and photon (single-muon) control regions. The dimuon control region is defined 
 using the same selection as for the signal region, but removing the muon veto. Instead, exactly 
-two isolated muons are required with opposite charge, $\pt^{\mu_{1},\mu_{2}}>20,10$ GeV and an 
-invariant mass in the range 60-120~\gev. 
+two isolated muons are required with opposite charge, $\pt^{\mu_{1},\mu_{2}}>20,10$\GeV and an 
+invariant mass in the range 60-120~\GeV. 
+
+As the decay branching ratio of \Zmm~is approximately six times smaller than that
+to neutrinos, the resulting statistical uncertainty on the \Zvvjets~background 
+becomes a dominant systematic uncertainty at large values of \ETm.  A
+complementary approach is to use events in data that have a high-$\pt$ photon
+recoiling against jets to further constrain the \Zvvjets~background~\cite{CMS-PAS-SUS-08-002}. 
+This is advantageous since the production
+cross-section of \phojets~is roughly three times that of the \Zvvjets~resulting in a
+smaller statistical uncertainty on the predicted background. The theoretical uncertainties 
+associated to the translation of the kinematics in $\phojets$ events to that of $\Zvvjets$ events 
+are however significant. A combination of both photon and dimuon control regions is therefore used 
+to maximally constrain the $\Zvvjets$ background.  
 
 The photon control region consists of events which are selected by a trigger requiring an 
-isolated photon with transverse momentum greater than 150 GeV~\cite{Khachatryan:2015iwa}. 
+isolated photon with transverse momentum greater than 150\GeV~\cite{Khachatryan:2015iwa}. 
 The selected events are required to have at least one photon with $p_{\mathrm{T}} > 170~\textrm{GeV}$ and 
 $|\eta|<2.5$, excluding photons in the ECAL transition region, $1.44 <
 |\eta|< 1.56$. All other kinematic selections are the smae as the
-signal region, where here teh photon is ingored in the $\ETm$ calculation.
+signal region, where here the photon is ignored in the $\ETm$ calculation.
 
 To estimate the $\Wlvjets$ background, a single-muon control region is defined by selecting events 
-with exactly one muon with $\pt$ larger than 20\gev. Additionally the transverse 
+with exactly one muon with $\pt$ larger than 20\GeV. Additionally the transverse 
 mass, calculated as $m_{\mathrm{T}}=\sqrt{2\ETm p_{\mathrm{T}}^{\mu} (1-\cos \phi)}$, where $\phi$ 
-is the angle between the muon and $\ETm$ vector in the transverse plane, must satisfy $50<m_{\mathrm{T}}<100$ \gev.
+is the angle between the muon and $\ETm$ vector in the transverse plane, must satisfy $50<m_{\mathrm{T}}<100$ \GeV.
 
 The events in the control regions are
 divided into the three  categories, using the same selection criteria
@@ -431,14 +477,6 @@ yielding a distribution of fake \ETm. The distribution of fake \ETm~in
 the control regions is used to derive the expectation from the \Zvvjets~and \Wlvjets~
 backgrounds in the signal region.
 
-As the decay branching ratio of \Zmm~is approximately six times smaller than that
-to neutrinos, the resulting statistical uncertainty on the \Zvvjets~background 
-becomes a dominant systematic uncertainty at large values of \ETm.  A
-complementary approach is to use events in data that have a high-$\pt$ photon
-recoiling against jets to further constrain the \Zvvjets~background~\cite{CMS-PAS-SUS-08-002}. 
-This is advantageous since the production
-cross-section of \phojets~is roughly three times that of the \Zvvjets~resulting in a
-smaller statistical uncertainty on the predicted background. 
  
 The \ETm spectra of the $\vjets$ backgrounds are determined through the
 use of the binned likelihood fit, simultaneously across all bins in the three control regions.
@@ -690,7 +728,7 @@ observed in data in the signal region. The expected distributions are evaluated
 after fitting to the observed data simultaneously across the (a) monojet, 
 (b) V-resolved and (c) V-boosted categories.  The gray bands indicate the post-fit
 uncertainty on the background, assuming no signal. The expected distribution
-assuming vector mediated DM production is shown for $m_{\mathrm{DM}}=10$ GeV and 
+assuming vector mediated DM production is shown for $m_{\mathrm{DM}}=10$\GeV and 
 $m_{\mathrm{MED}} = 1 $ TeV.  } \label{fig:post_fit_plots}\end{center}\end{figure*}
 
 Exclusion limits are set for these models using the asymptotic CLs method~\cite{cls} with a
@@ -718,7 +756,7 @@ scattering~\cite{Kurylov:2003ra,Hisano:2010ct,
 Cheung:2013pfa,Buchmueller:2014yoa}.  For the vector and scalar  models,
 the limits are compared with the measurements by
 LUX collaboration~\cite{Akerib:2012ys} which currently
-provides the strongest constraints for $m_{\rm{DM}} \gtrsim 4$ GeV~\cite{PhysRevLett.116.161301}. 
+provides the strongest constraints for $m_{\rm{DM}} \gtrsim 4$\GeV~\cite{PhysRevLett.116.161301}. 
 For axial vector couplings, the limits are compared with DM-proton scattering limits
 from PICO-2 collaborationL~\cite{Amole:2015lsj}.  For pseudoscalar interactions, direct
 detection bounds are strongly velocity suppressed.  The most appropriate
@@ -739,12 +777,12 @@ Figure~\ref{fig:masslims} shows the 90\% CL exclusions for the vector,
 axial vector, scalar and pseudoscalar mediator models.  The expected 90\% confidence
 level upper limit on the ratio of excluded cross section to the predicted
 cross-section ($\mu_{\textrm{up}}$), when assuming the mediator only couples to
-fermions, is shown by the blue color scale. These limits are calculated under
+fermions (fermionic), is shown by the blue color scale. These limits are calculated under
 the assumption that only the initial state partons and the DM particle
 contribute to the width of the mediator (minimum width
 constraint)~\cite{An:2012va,Abercrombie:2015wmb,Fox:2011pm,simplified1}. 
 For the pseudoscalar interpretation, there is a region of  
-masses between 150 and 280 GeV for which the decrease in 
+masses between 150 and 280\GeV for which the decrease in 
 cross-section with larger mediator mass is balanced by an increase in acceptance for the 
 signal so that the expected signal contribution remains roughly constant. The expected 
 value of $\mu_{\mathrm{up}}$ is larger than 1 for this region resulting in an  
@@ -776,7 +814,7 @@ $m_{\textrm{med}}-m_{\textrm{DM}}$ plane assuming (a) vector, (b) axial vector,
 (c) scalar, and (d) pseudoscalar mediators.  The blue scale shows the expected 
 90\% CL exclusion upper limit on the signal strength assuming the mediator only couples to
 fermions. For the scalar and pseudoscalar mediators, the exclusion contour
-assuming coupling only to fermions is explicitly shown by the orange line. The
+assuming coupling only to fermions (fermionic) is explicitly shown by the orange line. The
 white region shows model points which were not tested when assuming coupling
 only to fermions and are not expected to be excluded by this analysis under this
 assumption.  The excluded region is to the bottom/left of the contours in
@@ -838,7 +876,7 @@ Under the simplified model used, all of these regions are excluded by this analy
 $m_{\textrm{DM}}-\sigma_{\textrm{DM}}$ plane assuming (a) vector, (b) axial vector, 
 (c) scalar, and (d) pseudoscalar mediators.  For the scalar and pseudoscalar
 case, the orange line shows the exclusion contours assuming the mediator only
-couples to fermions. The excluded region in all plots is to the top/left of the
+couples to fermions (fermionic). The excluded region in all plots is to the top/left of the
 contours. In the vector and axial vector scenarios, limits are shown
 independently for monojet, V-boosted and V-resolved categories. The partial
 combination of the V-tag categories  is
@@ -857,9 +895,9 @@ data correspond to an integrated luminosity of 19.7\fbinv collected with the CMS
 detector at the LHC.  This search is the first at CMS to utilise sub-structure
 techniques in order to identify hadronically decaying vector bosons in both
 boosted and resolved scenarios. Sensitivity to a potential mono-V signature is
-achieved by categorising the events according to the origin of the jets in the
-event as either quark/gluon radiation or from a hadronically decaying vector
-boson through these techniques.  The sensitivity is further increased by using
+achieved by the addition of two event categories which select hadronically decaying vector
+boson using novel jet substructure techniques. 
+The sensitivity of the search has been increased compared to the previous CMS result by using
 the full shape of the $\ETm$ distribution to discriminate signal from standard
 model backgrounds.  No significant deviation from the expectation from SM
 backgrounds is observed in the \ETm distributions.  The results of the search

--- a/trunk/comments_Rutgers.txt
+++ b/trunk/comments_Rutgers.txt
@@ -117,7 +117,9 @@ We have removed the deltaphi(ca8,ak5) since its not used again. Added “, other
  Figure 2: why is the DM t2/t1 distribution different from diboson distribution?
           You should mention the reason in the text.
 
-Kevin? Is it number of jets in the final state?
+One small effect is due to the fact that its a stacked plot (diboson is on top of the others background). 
+Hoever, there is some difference due to the fact that the diboson also has the leptonic decays which tend to 
+be at higher values of tau2/tau1
 
 Also on Figure 2: The systematic uncertainties are not shown yet the statement is made that the
   disagreement is covered.  It would be very useful to have an estimate of the systematic uncertainty band in

--- a/trunk/comments_Rutgers.txt
+++ b/trunk/comments_Rutgers.txt
@@ -1,0 +1,184 @@
+Dear authors,
+
+we enjoyed reading your paper. Please find some minor comments below.
+Congratulations on bringing this important analysis to publication.
+
+The Rutgers group
+
+--------
+
+Title:  It’s a little awkward (especially since “jets” could refer to monojet signature).
+          suggest: “Search for dark matter pair production in association with a gluon or a vector boson
+          with CMS at sqrt(s)=8TeV”
+
+We think gluon is a bit specific. We leave this to the language editor
+
+6: How about
+    “Astrophysical observations suggest existence of dark matter (DM) - an unknown non-baryonic form
+     of matter in the Universe, and require physics beyond the standard model (SM).”
+
+We prefer to keep the sentence as is.
+
+10: It would be good to avoid “model-dependent” here. The production cross section here is
+      far from model-independent. You can say that mono-jet has sensitivity to a wider range of models,
+      while V/Z production is a more targeted (but lower background) final state. Also, V=W or Z boson would
+       be better incorporated as a parenthetical statement (Where V=W or Z boson)
+
+Agreed, we’ve adopted the suggestions
+
+22: The sentence “The exploration of …” is a fragment. Is it supposed to say anything except that we use
+       novel jet substructure methods? Suggest to rephrase the paragraph so it simply says that
+       mono-V search is done using jet substructure methods at high boosts and using multivariate V-tagging
+       at moderate boosts where jets from V decays are well-resolved.
+
+Agreed, the sentences now read :
+" The mono-V search uses recently developed techniques designed to exploit information available in the jet's substructure when the V-boson is highly boosted and uses a multivariate V-tagging technique to identify the individual jets from moderately boosted V-bosons. "
+
+24:  extraneous "of"
+
+Fixed
+
+27: The section numbers here are off.
+
+Fixed, thanks
+
+55:  Here the paper switches to standard model and dark matter instead of SM and DM
+
+Fixed throughout to use SM and DM
+
+61: This paragraph is either too much or too little information. Either expand on what is done, or
+      (probably better) just make reference to theory papers. Also, we did not find any mention of
+       “fermionic DM production” further in the paper. This is confusing.
+
+The discussion was added to be more explicit as requested during ARC review. We feel it is sufficient to follow the setup of the models used.
+“fermionic” is mentioned in Figs 7 and 8, now added also in the text and captions.
+
+71: the sentence “The mono-V or monojet signatures…”:  presumably it only refers to 1c?
+      Why not make diagrams with explicit gluon or V ISR and refer to them as 1c and 1d?
+
+Added additional Diagrams
+
+72: “In all models…”: talking about the choice of model parameters would make more sense above,
+       where you present the langrangians. Also, please rephrase the sentence about the width.
+       If we understand correctly, you assume that the mediator does not have any couplings except to
+       quarks and DM.
+
+We moved the “In all models” closer to the lagrangians. We have rephrased the width sentence to read “For the fermionic models considered, the width is determined under the minimum width constraint requiring that only quarks and DM particles couple to the mediator. For the case in which couplings between the mediator and V-bosons are allowed, the width is modified to account for the additional contributions which these couplings allow [14]."
+
+87: the purpose of this paragraph is unclear. Suggest to drop it and proceed directly to the trigger description.
+
+It gives a very brief introduction as to the key features of the selection. We’d prefer to keep it
+
+90: drop “either of”, and change to past tense. May be, instead say simply “The data used for this analysis were collected using two ETmiss triggers”
+
+Agree, done
+
+91(and elsewhere):  large space beside GeV compared to say L83
+
+We’ve now harmonised to use the usual \GeV everywhere.
+
+94: “together with at least one jet”
+
+Done
+
+95: “in order to maintain” -> “to ensure”
+
+Done
+
+97: “from clustering of “ -> “by clustering the “.
+      “Both” is confusing here. You probably should refer to the two different analyses here, (see comment
+      on line 22 above)
+
+Left this for LE
+
+102: “the absolute scale of the jet energy” -> “the jet energy scale”
+
+Was modified to this during review, we will re-discuss it with LE
+
+103: you define ETmiss as a magnitude, but then in the next sentence talk about the angle between
+        ETmiss and the leading jet.
+
+Replaced with ETmiss vector
+
+111:  This paragraph probably needs to move up in the text (see comment on line 22 above)
+
+We prefer to discuss the trigger before classification
+
+127: N-subjettiness
+
+Thanks, fixed
+
+133: suggest change \phi to some other letter, not to be confused with asimuthal angle.
+         the sentence may need rephrasing to spell out that even events with one additional ak5 jet are
+         rejected if the opening angle is greater then 2.
+
+We have removed the deltaphi(ca8,ak5) since its not used again. Added “, otherwise it is rejected” to spell out the cut.
+
+ Figure 2: why is the DM t2/t1 distribution different from diboson distribution?
+          You should mention the reason in the text.
+
+Kevin? Is it number of jets in the final state?
+
+Also on Figure 2: The systematic uncertainties are not shown yet the statement is made that the
+  disagreement is covered.  It would be very useful to have an estimate of the systematic uncertainty band in
+  the plot.
+
+This is discussed later in the text, we prefer not to add systematics which are not so well defined on a single variable. Especially given the fact that the systematic accounts for a migration across the cut which is difficult to shown on the plot.
+
+Figure 4:  Same comment as on Figure 2 above because the statistical uncertainties are much too small to cover the disagreement, so it would be interesting to see if the systematics do indeed cover the (in some cases large) disagreement
+
+As above.
+
+141: you really need to spell out how events are classified to ensure the orthogonality of selection.
+        Which cuts on fat jet events do you make to separate them from the rest? All of the ones described in
+         the previous paragraph? If so, 141 should start with something like “Events failing the selection
+        above… “
+
+We say for the resolved category now, “ … selection that looks for decays into a pair of ak5 jets is applied to recover the event if it fails the V-boosted selection.
+
+153: is there a number of jets cut on the resolved V->jj category?
+
+No
+
+157: which category you are calling monojet? Your categories names are inconsistent throughout the paper. Please pick one set and stick to it.
+
+“this” was meant to refer to the monojet category just described (i.e events failing the other two “V-tag” categories. Originally, we had “The monojet category” but was asked to modify to this. Now we add a sentence to clarify which reads .. “ This final category is referred to herein as the monojet category. For the monojet category…"
+
+161: the paper would be much clearer if you make a table describing all the cuts in
+each category.
+
+A good idea, we have added such a table
+
+175: “)” is missing.
+        You have three categories, you mention two here.
+
+ V-tag refers to both V-resolved and V-boosted, rephrased to "A binned likelihood fit is performed in the ranges 250-1000 \GeV and 200-1000 \GeV for the V-tag (V-boosted and V-resolved) and monojet events, respectively."
+
+192: you already used word “category” to define fat jet, V-tag, and the gluon category. Use something
+    else - sub-category, may be?
+
+These really are the same categories as for the signal region so we leave it as category.
+
+199: this paragraph is out of order. You should say what it says above, line 180 or so.
+
+This has been moved
+
+205: you should mention that statistical improvement comes at a price of extra theory uncertainties.
+       at 1000 GeV, which is the end of your MET window, the electroweak corrections, for example, are
+       large (tens of %), and definitely different for photons and Z’s.
+
+Indeed, these systematics are discussed later in the text. We added this caveat and use it to motivate the use of both control regions
+
+Figure 7,8: we should somehow note the very different basic uncertainties that go into these contours.
+Our uncertainties are in luminosity,  cross-sections and acceptances while the direct measurements uncertainties are quantities like  DM density in the solar system and relative velocity of the DM wrt earth.
+A reader  looking at Fig 7, 8 should be aware of these differences in experimental technique.
+
+We only add these lines directly from the public plots available from the DD experiments. We feel a discussion of their systematics would be out of place in this paper.
+
+340: the sentence about mono-V signature should be rewritten. It’s unclear which category you mean (you have two V categories), and it is hard for a reader to understand what “origin of the jets”, for example.
+A convincing case could be made that the statements about sensitivity do not belong in the summary.
+They are better suited for the introduction, where you can talk about the improvements to the
+previous CMS analysis.
+
+This has been re-written to down play “sensitivity”. We wish to re-iterate the use of the mono-V(had) search which is a first for CMS so prefer to leave the statement there. However, we’ve re-written to
+"Sensitivity to a potential mono-V signature is achieved by the addition of two event categories which select hadronically decaying vector boson using novel jet substructure techniques.”


### PR DESCRIPTION
Dear authors,

we enjoyed reading your paper. Please find some minor comments below.
Congratulations on bringing this important analysis to publication.

The Rutgers group

---

Title:  It’s a little awkward (especially since “jets” could refer to monojet signature).
          suggest: “Search for dark matter pair production in association with a gluon or a vector boson
          with CMS at sqrt(s)=8TeV”

We think gluon is a bit specific. We leave this to the language editor

6: How about
    “Astrophysical observations suggest existence of dark matter (DM) - an unknown non-baryonic form
     of matter in the Universe, and require physics beyond the standard model (SM).”

We prefer to keep the sentence as is.

10: It would be good to avoid “model-dependent” here. The production cross section here is
      far from model-independent. You can say that mono-jet has sensitivity to a wider range of models,
      while V/Z production is a more targeted (but lower background) final state. Also, V=W or Z boson would
       be better incorporated as a parenthetical statement (Where V=W or Z boson)

Agreed, we’ve adopted the suggestions

22: The sentence “The exploration of …” is a fragment. Is it supposed to say anything except that we use
       novel jet substructure methods? Suggest to rephrase the paragraph so it simply says that
       mono-V search is done using jet substructure methods at high boosts and using multivariate V-tagging
       at moderate boosts where jets from V decays are well-resolved.

Agreed, the sentences now read :
" The mono-V search uses recently developed techniques designed to exploit information available in the jet's substructure when the V-boson is highly boosted and uses a multivariate V-tagging technique to identify the individual jets from moderately boosted V-bosons. "

24:  extraneous "of"

Fixed

27: The section numbers here are off.

Fixed, thanks

55:  Here the paper switches to standard model and dark matter instead of SM and DM

Fixed throughout to use SM and DM

61: This paragraph is either too much or too little information. Either expand on what is done, or
      (probably better) just make reference to theory papers. Also, we did not find any mention of
       “fermionic DM production” further in the paper. This is confusing.

The discussion was added to be more explicit as requested during ARC review. We feel it is sufficient to follow the setup of the models used.
“fermionic” is mentioned in Figs 7 and 8, now added also in the text and captions.

71: the sentence “The mono-V or monojet signatures…”:  presumably it only refers to 1c?
      Why not make diagrams with explicit gluon or V ISR and refer to them as 1c and 1d?

Added additional Diagrams

72: “In all models…”: talking about the choice of model parameters would make more sense above,
       where you present the langrangians. Also, please rephrase the sentence about the width.
       If we understand correctly, you assume that the mediator does not have any couplings except to
       quarks and DM.

We moved the “In all models” closer to the lagrangians. We have rephrased the width sentence to read “For the fermionic models considered, the width is determined under the minimum width constraint requiring that only quarks and DM particles couple to the mediator. For the case in which couplings between the mediator and V-bosons are allowed, the width is modified to account for the additional contributions which these couplings allow [14]."

87: the purpose of this paragraph is unclear. Suggest to drop it and proceed directly to the trigger description.

It gives a very brief introduction as to the key features of the selection. We’d prefer to keep it

90: drop “either of”, and change to past tense. May be, instead say simply “The data used for this analysis were collected using two ETmiss triggers”

Agree, done

91(and elsewhere):  large space beside GeV compared to say L83

We’ve now harmonised to use the usual \GeV everywhere.

94: “together with at least one jet”

Done

95: “in order to maintain” -> “to ensure”

Done

97: “from clustering of “ -> “by clustering the “.
      “Both” is confusing here. You probably should refer to the two different analyses here, (see comment
      on line 22 above)

Left this for LE

102: “the absolute scale of the jet energy” -> “the jet energy scale”

Was modified to this during review, we will re-discuss it with LE

103: you define ETmiss as a magnitude, but then in the next sentence talk about the angle between
        ETmiss and the leading jet.

Replaced with ETmiss vector

111:  This paragraph probably needs to move up in the text (see comment on line 22 above)

We prefer to discuss the trigger before classification

127: N-subjettiness

Thanks, fixed

133: suggest change \phi to some other letter, not to be confused with asimuthal angle.
         the sentence may need rephrasing to spell out that even events with one additional ak5 jet are
         rejected if the opening angle is greater then 2.

We have removed the deltaphi(ca8,ak5) since its not used again. Added “, otherwise it is rejected” to spell out the cut.

 Figure 2: why is the DM t2/t1 distribution different from diboson distribution?
          You should mention the reason in the text.

One small effect is due to the fact that its a stacked plot (diboson is on top of the others background).
Hoever, there is some difference due to the fact that the diboson also has the leptonic decays which tend to
be at higher values of tau2/tau1

Also on Figure 2: The systematic uncertainties are not shown yet the statement is made that the
  disagreement is covered.  It would be very useful to have an estimate of the systematic uncertainty band in
  the plot.

This is discussed later in the text, we prefer not to add systematics which are not so well defined on a single variable. Especially given the fact that the systematic accounts for a migration across the cut which is difficult to shown on the plot.

Figure 4:  Same comment as on Figure 2 above because the statistical uncertainties are much too small to cover the disagreement, so it would be interesting to see if the systematics do indeed cover the (in some cases large) disagreement

As above.

141: you really need to spell out how events are classified to ensure the orthogonality of selection.
        Which cuts on fat jet events do you make to separate them from the rest? All of the ones described in
         the previous paragraph? If so, 141 should start with something like “Events failing the selection
        above… “

We say for the resolved category now, “ … selection that looks for decays into a pair of ak5 jets is applied to recover the event if it fails the V-boosted selection.

153: is there a number of jets cut on the resolved V->jj category?

No

157: which category you are calling monojet? Your categories names are inconsistent throughout the paper. Please pick one set and stick to it.

“this” was meant to refer to the monojet category just described (i.e events failing the other two “V-tag” categories. Originally, we had “The monojet category” but was asked to modify to this. Now we add a sentence to clarify which reads .. “ This final category is referred to herein as the monojet category. For the monojet category…"

161: the paper would be much clearer if you make a table describing all the cuts in
each category.

A good idea, we have added such a table

175: “)” is missing.
        You have three categories, you mention two here.

 V-tag refers to both V-resolved and V-boosted, rephrased to "A binned likelihood fit is performed in the ranges 250-1000 \GeV and 200-1000 \GeV for the V-tag (V-boosted and V-resolved) and monojet events, respectively."

192: you already used word “category” to define fat jet, V-tag, and the gluon category. Use something
    else - sub-category, may be?

These really are the same categories as for the signal region so we leave it as category.

199: this paragraph is out of order. You should say what it says above, line 180 or so.

This has been moved

205: you should mention that statistical improvement comes at a price of extra theory uncertainties.
       at 1000 GeV, which is the end of your MET window, the electroweak corrections, for example, are
       large (tens of %), and definitely different for photons and Z’s.

Indeed, these systematics are discussed later in the text. We added this caveat and use it to motivate the use of both control regions

Figure 7,8: we should somehow note the very different basic uncertainties that go into these contours.
Our uncertainties are in luminosity,  cross-sections and acceptances while the direct measurements uncertainties are quantities like  DM density in the solar system and relative velocity of the DM wrt earth.
A reader  looking at Fig 7, 8 should be aware of these differences in experimental technique.

We only add these lines directly from the public plots available from the DD experiments. We feel a discussion of their systematics would be out of place in this paper.

340: the sentence about mono-V signature should be rewritten. It’s unclear which category you mean (you have two V categories), and it is hard for a reader to understand what “origin of the jets”, for example.
A convincing case could be made that the statements about sensitivity do not belong in the summary.
They are better suited for the introduction, where you can talk about the improvements to the
previous CMS analysis.

This has been re-written to down play “sensitivity”. We wish to re-iterate the use of the mono-V(had) search which is a first for CMS so prefer to leave the statement there. However, we’ve re-written to
"Sensitivity to a potential mono-V signature is achieved by the addition of two event categories which select hadronically decaying vector boson using novel jet substructure techniques.”
